### PR TITLE
Expose functions to bypass zip file bundles

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -11,7 +11,7 @@ func NewClusterFromBundle(path, username, password string, timeout time.Duration
 	if err != nil {
 		return nil, err
 	}
-	return newCluster(dialer, username, password), nil
+	return NewCluster(dialer, username, password), nil
 }
 
 func NewClusterFromURL(url, databaseID, token string, timeout time.Duration) (*gocql.ClusterConfig, error) {
@@ -19,10 +19,10 @@ func NewClusterFromURL(url, databaseID, token string, timeout time.Duration) (*g
 	if err != nil {
 		return nil, err
 	}
-	return newCluster(dialer, "token", token), nil
+	return NewCluster(dialer, "token", token), nil
 }
 
-func newCluster(dialer gocql.HostDialer, username, password string) *gocql.ClusterConfig {
+func NewCluster(dialer gocql.HostDialer, username, password string) *gocql.ClusterConfig {
 	cluster := gocql.NewCluster("0.0.0.0") // Placeholder, maybe figure how to make this better
 	cluster.HostDialer = dialer
 	cluster.PoolConfig = gocql.PoolConfig{HostSelectionPolicy: gocql.RoundRobinHostPolicy()}

--- a/dialer.go
+++ b/dialer.go
@@ -54,6 +54,13 @@ func NewDialerFromURL(url, databaseID, token string, timeout time.Duration) (goc
 	}, nil
 }
 
+func NewDialer(b *astra.Bundle, timeout time.Duration) (gocql.HostDialer, error) {
+	return &dialer{
+		bundle:  b,
+		timeout: timeout,
+	}, nil
+}
+
 func (d *dialer) DialHost(ctx context.Context, host *gocql.HostInfo) (*gocql.DialedHost, error) {
 	sniAddr, contactPoints, err := d.resolveMetadata(ctx)
 	if err != nil {


### PR DESCRIPTION
This exposes creating a gocql.HostDialer directly from an *astra.Bundle and not needed a zip file. This also let's users create a cluster with these custom Dialers.