### PR TITLE
Add alternate env vars 

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -12,9 +12,9 @@ import (
 )
 
 type runConfig struct {
-	AstraBundle     string        `yaml:"astra-bundle" help:"Path to secure connect bundle for an Astra database. Requires '--username' and '--password'. Ignored if using the token or contact points option." short:"b" env:"ASTRA_BUNDLE"`
-	AstraToken      string        `yaml:"astra-token" help:"Token used to authenticate to an Astra database. Requires '--astra-database-id'. Ignored if using the bundle path or contact points option." short:"t" env:"ASTRA_TOKEN"`
-	AstraDatabaseID string        `yaml:"astra-database-id" help:"Database ID of the Astra database. Requires '--astra-token'" short:"i" env:"ASTRA_DATABASE_ID"`
+	AstraBundle     string        `yaml:"astra-bundle" help:"Path to secure connect bundle for an Astra database. Requires '--username' and '--password'. Ignored if using the token or contact points option." short:"b" env:"ASTRA_BUNDLE,ASTRA_DB_SECURE_BUNDLE_PATH"`
+	AstraToken      string        `yaml:"astra-token" help:"Token used to authenticate to an Astra database. Requires '--astra-database-id'. Ignored if using the bundle path or contact points option." short:"t" env:"ASTRA_TOKEN,ASTRA_DB_APPLICATION_TOKEN"`
+	AstraDatabaseID string        `yaml:"astra-database-id" help:"Database ID of the Astra database. Requires '--astra-token'" short:"i" env:"ASTRA_DATABASE_ID,ASTRA_DB_ID"`
 	AstraApiURL     string        `yaml:"astra-api-url" help:"URL for the Astra API" default:"https://api.astra.datastax.com" env:"ASTRA_API_URL"`
 	AstraTimeout    time.Duration `yaml:"astra-timeout" help:"Timeout for contacting Astra when retrieving the bundle and metadata" default:"10s" env:"ASTRA_TIMEOUT"`
 	Username        string        `yaml:"username" help:"Username to use for authentication" short:"u" env:"USERNAME"`

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/datastax/gocql-astra
 go 1.18
 
 require (
-	github.com/alecthomas/kong v0.6.1 // indirect
+	github.com/alecthomas/kong v0.7.2-0.20230131193930-9610ed62d939 // indirect
 	github.com/datastax/astra-client-go/v2 v2.2.9 // indirect
 	github.com/datastax/cql-proxy v0.1.3 // indirect
 	github.com/datastax/go-cassandra-native-protocol v0.0.0-20211124104234-f6aea54fa801 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/alecthomas/kong v0.2.17 h1:URDISCI96MIgcIlQyoCAlhOmrSw6pZScBNkctg8r0W
 github.com/alecthomas/kong v0.2.17/go.mod h1:ka3VZ8GZNPXv9Ov+j4YNLkI8mTuhXyr/0ktSlqIydQQ=
 github.com/alecthomas/kong v0.6.1 h1:1kNhcFepkR+HmasQpbiKDLylIL8yh5B5y1zPp5bJimA=
 github.com/alecthomas/kong v0.6.1/go.mod h1:JfHWDzLmbh/puW6I3V7uWenoh56YNVONW+w8eKeUr9I=
+github.com/alecthomas/kong v0.7.2-0.20230131193930-9610ed62d939 h1:asEjSsAwQVXPbo8JvkjlSJ/TF5reRNs5+gJrpn6G2wc=
+github.com/alecthomas/kong v0.7.2-0.20230131193930-9610ed62d939/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
 github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=


### PR DESCRIPTION
Update kong to get to [this commit](https://github.com/alecthomas/kong/commit/9610ed62d93992d4f13e210ada9fd0917530f079) which adds support for multiple names for a given env var.  We can then use this to support the env vars referenced in [this PR](https://github.com/datastax/gocql-astra/pull/7) without requiring a new example.

Note that [the comment about re-organizing the layout of the repo](https://github.com/datastax/gocql-astra/pull/7#issuecomment-1507273684) still seem like a pretty good idea.